### PR TITLE
fix: Correct additional_configuration ordering for runtime_monitoring

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -181,20 +181,20 @@ resource "aws_guardduty_organization_configuration_feature" "runtime_monitoring"
   auto_enable = var.auto_enable_organization_members
 
   # Use dynamic blocks with explicit list ordering to avoid order-based drift
-  # AWS returns these in this specific order: EKS, EC2, ECS (not alphabetical)
+  # AWS returns these in this specific order: ECS, EC2, EKS (based on observed API behavior)
   dynamic "additional_configuration" {
     for_each = [
       {
-        name        = "EKS_ADDON_MANAGEMENT"
-        auto_enable = var.runtime_monitoring_additional_config.eks_addon_management_enabled ? var.auto_enable_organization_members : "NONE"
+        name        = "ECS_FARGATE_AGENT_MANAGEMENT"
+        auto_enable = var.runtime_monitoring_additional_config.ecs_fargate_agent_management_enabled ? var.auto_enable_organization_members : "NONE"
       },
       {
         name        = "EC2_AGENT_MANAGEMENT"
         auto_enable = var.runtime_monitoring_additional_config.ec2_agent_management_enabled ? var.auto_enable_organization_members : "NONE"
       },
       {
-        name        = "ECS_FARGATE_AGENT_MANAGEMENT"
-        auto_enable = var.runtime_monitoring_additional_config.ecs_fargate_agent_management_enabled ? var.auto_enable_organization_members : "NONE"
+        name        = "EKS_ADDON_MANAGEMENT"
+        auto_enable = var.runtime_monitoring_additional_config.eks_addon_management_enabled ? var.auto_enable_organization_members : "NONE"
       },
     ]
 


### PR DESCRIPTION
## Describe the Bug

The `runtime_monitoring` resource's `additional_configuration` blocks are ordered incorrectly, causing perpetual drift on every `terraform plan`. The AWS API returns these blocks in a specific order that differs from what was in the code.

## Expected Behavior

Running `terraform plan` after a successful apply should show no changes for the `aws_guardduty_organization_configuration_feature.runtime_monitoring` resource.

## Steps to Reproduce

1. Deploy `aws-guardduty/org-settings` with `runtime_monitoring_enabled: true`
2. Run `terraform plan` again
3. See perpetual replacement diff:
```
# aws_guardduty_organization_configuration_feature.runtime_monitoring[0] must be replaced
-/+ resource "aws_guardduty_organization_configuration_feature" "runtime_monitoring" {
      ~ additional_configuration {
          ~ name = "ECS_FARGATE_AGENT_MANAGEMENT" -> "EKS_ADDON_MANAGEMENT" # forces replacement
        }
      ~ additional_configuration {
          ~ name = "EKS_ADDON_MANAGEMENT" -> "EC2_AGENT_MANAGEMENT" # forces replacement
        }
        # (1 unchanged block hidden)
    }
```

## Root Cause

The AWS API returns `additional_configuration` blocks in a specific order: `ECS, EC2, EKS`

The code had them ordered as: `EKS, EC2, ECS`

Since Terraform compares blocks by position (not by name), this ordering mismatch caused every plan to show a diff.

## Fix

Reorder the blocks to match AWS's actual return order:
1. `ECS_FARGATE_AGENT_MANAGEMENT`
2. `EC2_AGENT_MANAGEMENT`
3. `EKS_ADDON_MANAGEMENT`

## Environment

- OpenTofu 1.10.x
- AWS Provider 5.x
- Tested in `eu-west-1`, `ca-central-1`, `ap-southeast-2` and `us-east-1`.